### PR TITLE
Removed docker.sock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       KAFKA_MESSAGE_MAX_BYTES: 999999999
       KAFKA_LOG_DIRS: /kafka/kafka-logs-1
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       - kafka_data:/kafka
 
     depends_on:


### PR DESCRIPTION
It is used for communication to docker deamon from inside docker (technical terminology: "docker-in-docker"). Since we have defined the ports for kafka ("9092:9092" and "9094:9094"), kafka will function normally without docker.sock.
Links for further reading (https://github.com/wurstmeister/kafka-docker/wiki#why-is-varrundockersock-needed, https://github.com/wurstmeister/kafka-docker/issues/81)